### PR TITLE
[WIP] add github actions for auto binary generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,58 @@
+name: build binaries
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build_matrix:
+    strategy:
+      matrix:
+        env: [linux, windows, macos]
+        include:
+          - env: linux
+            os: ubuntu-latest
+            bin: twitchTransFN
+            archive: tar.gz
+          - env: windows
+            os: windows-latest
+            bin: twitchTransFN.exe
+            archive: zip
+          - env: macos
+            os: macos-latest
+            bin: twitchTransFN.command
+            archive: tar.gz
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: setup python
+        uses: actions/setup-python@v4
+        with: { python-version: 3.8 }
+
+      - name: install pyinstaller
+        run: python -m pip install --upgrade pip PyInstaller
+
+      - name: install requirements
+        run: python -m pip install -r requirements.txt
+
+      - name: build
+        run: pyinstaller --exclude-module config --name ${{ matrix.bin }} -F twitchTransFN.py
+
+      - name: archive with zip
+        if: ${{ matrix.archive == 'zip' }}
+        run: powershell Compress-Archive -Path dist/${{ matrix.bin }} -DestinationPath ${{ matrix.env }}.zip
+
+      - name: archive with tar.gz
+        if: ${{ matrix.archive == 'tar.gz' }}
+        run: tar -C dist -pczvf ${{ matrix.env }}.tar.gz ${{ matrix.bin }}
+
+      - name: update github release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          prerelease: false
+          files: ${{ matrix.env }}.${{ matrix.archive }}


### PR DESCRIPTION
**Currently, this PR is Working in Progress.** / **まだちょっと作業中です**

# What is this?
- Github Actionsを利用して、3つのOS環境(Windows, Mac, Linux)におけるバイナリを生成するものです。
- このGithub Actionsを起動するためには `vX.Y.Z` のようなSematnicsVersioning的な名称を持ったタグを作成することで行なえます。特にGithub上のRelease機能を利用してそのような名前のReleaseをつくることで付随的にTagが作成されるので利用できるでしょう。
- 生成したバイナリは Github Releases に登録され、ダウンロードできる状態で記録されます。

# How implemented this PR?
- Github ActionsのWorkflowを定義しました。
- バイナリ生成にはPyInstallerを利用しています。

# Note
- 現状特になし