### PR TITLE
ビルド用のファイルを追加

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ jobs:
             os: macos-latest
             bin: twitchTransFN.command
             archive: tar.gz
+            arch: _intel
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
@@ -35,25 +36,37 @@ jobs:
         with:
             python-version: '3.10'
 
-      - name: install pyinstaller
-        run: python -m pip install --upgrade pip PyInstaller
+      - name: upgrade pip
+        run: python -m pip install --upgrade pip setuptools wheel
+
+      - name: build pyinstaller
+        continue-on-error: true
+        run: |
+          git clone https://github.com/pyinstaller/pyinstaller
+          cd ./pyinstaller/bootloader
+          python ./waf distclean all
+          cd ../
+          python setup.py install
+          cd ../
 
       - name: install requirements
         run: python -m pip install -r requirements.txt
 
       - name: build
-        run: pyinstaller ${{ matrix.opts }} --runtime-tmpdir="." --icon icon.ico --exclude-module="config" --name ${{ matrix.bin }} -F twitchTransFN.py
-        
+        run: pyinstaller ${{ matrix.opts }} --runtime-tmpdir="./" --icon icon.ico --exclude-module="config" --name ${{ matrix.bin }} -F twitchTransFN.py
+
       - name: move config.py
         run: mv config.py dist/
-      
+
       - name: archive with zip
         if: ${{ matrix.archive == 'zip' }}
         run: powershell Compress-Archive -Path dist/* -DestinationPath ${{'twitchTransFN_'}}${{ matrix.env }}.zip
 
       - name: archive with tar.gz
         if: ${{ matrix.archive == 'tar.gz' }}
-        run: mv dist ${{'twitchTransFN_'}}${{ matrix.env }} && tar acvf ${{'twitchTransFN_'}}${{ matrix.env }}.tar.gz ${{'twitchTransFN_'}}${{ matrix.env }}
+        run: |
+          mv dist ${{'twitchTransFN_'}}${{ matrix.env }}
+          tar acvf ${{'twitchTransFN_'}}${{ matrix.env }}${{ matrix.arch }}.tar.gz ${{'twitchTransFN_'}}${{ matrix.env }}
 
       - name: update github release
         id: create_release
@@ -61,4 +74,4 @@ jobs:
         with:
           draft: false
           prerelease: false
-          files: ${{'twitchTransFN_'}}${{ matrix.env }}.${{ matrix.archive }}
+          files: ${{'twitchTransFN_'}}${{ matrix.env }}${{ matrix.arch }}.${{ matrix.archive }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,6 @@ jobs:
           - env: windows
             os: windows-latest
             bin: twitchTransFN.exe
-            opts: --hidden-import=pywin32
             archive: zip
           - env: macos
             os: macos-latest
@@ -34,7 +33,7 @@ jobs:
       - name: setup python
         uses: actions/setup-python@v4
         with:
-            python-version: '3.10'
+          python-version: "3.10"
 
       - name: upgrade pip
         run: python -m pip install --upgrade pip setuptools wheel
@@ -53,7 +52,7 @@ jobs:
         run: python -m pip install -r requirements.txt
 
       - name: build
-        run: pyinstaller ${{ matrix.opts }} --runtime-tmpdir="./" --icon icon.ico --exclude-module="config" --name ${{ matrix.bin }} -F twitchTransFN.py
+        run: python build.py
 
       - name: move config.py
         run: mv config.py dist/

--- a/build.py
+++ b/build.py
@@ -1,0 +1,37 @@
+import platform
+
+import PyInstaller.__main__
+
+OS = platform.system()
+
+if OS == 'Windows':
+    PyInstaller.__main__.run([
+        'twitchTransFN.py',
+        '--clean',
+        '--onefile',
+        '--hidden-import=pywin32',
+        '--runtime-tmpdir="./"',
+        '--icon=icon.ico',
+        '--exclude-module="config"',
+        '--name=twitchTransFN.exe'
+    ])
+elif OS == 'Darwin':
+    PyInstaller.__main__.run([
+        'twitchTransFN.py',
+        '--clean',
+        '--onefile',
+        '--runtime-tmpdir="./"',
+        '--icon=icon.ico',
+        '--exclude-module="config"',
+        '--name=twitchTransFN.command'
+    ])
+elif OS == 'Linux':
+    PyInstaller.__main__.run([
+        'twitchTransFN.py',
+        '--clean',
+        '--onefile',
+        '--runtime-tmpdir="./"',
+        '--icon=icon.ico',
+        '--exclude-module="config"',
+        '--name=twitchTransFN'
+    ])

--- a/build.py
+++ b/build.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 
 import PyInstaller.__main__
 
@@ -10,7 +11,7 @@ if OS == 'Windows':
         '--clean',
         '--onefile',
         '--hidden-import=pywin32',
-        '--runtime-tmpdir="."',
+        '--runtime-tmpdir=.',
         '--icon=icon.ico',
         '--exclude-module=config',
         '--name=twitchTransFN.exe'
@@ -20,7 +21,7 @@ elif OS == 'Darwin':
         'twitchTransFN.py',
         '--clean',
         '--onefile',
-        '--runtime-tmpdir="."',
+        '--runtime-tmpdir=.',
         '--icon=icon.ico',
         '--exclude-module=config',
         '--name=twitchTransFN.command'
@@ -30,8 +31,10 @@ elif OS == 'Linux':
         'twitchTransFN.py',
         '--clean',
         '--onefile',
-        '--runtime-tmpdir="."',
+        '--runtime-tmpdir=.',
         '--icon=icon.ico',
         '--exclude-module=config',
         '--name=twitchTransFN'
     ])
+else:
+    sys.exit(1)

--- a/build.py
+++ b/build.py
@@ -10,9 +10,9 @@ if OS == 'Windows':
         '--clean',
         '--onefile',
         '--hidden-import=pywin32',
-        '--runtime-tmpdir="./"',
+        '--runtime-tmpdir="."',
         '--icon=icon.ico',
-        '--exclude-module="config"',
+        '--exclude-module=config',
         '--name=twitchTransFN.exe'
     ])
 elif OS == 'Darwin':
@@ -20,9 +20,9 @@ elif OS == 'Darwin':
         'twitchTransFN.py',
         '--clean',
         '--onefile',
-        '--runtime-tmpdir="./"',
+        '--runtime-tmpdir="."',
         '--icon=icon.ico',
-        '--exclude-module="config"',
+        '--exclude-module=config',
         '--name=twitchTransFN.command'
     ])
 elif OS == 'Linux':
@@ -30,8 +30,8 @@ elif OS == 'Linux':
         'twitchTransFN.py',
         '--clean',
         '--onefile',
-        '--runtime-tmpdir="./"',
+        '--runtime-tmpdir="."',
         '--icon=icon.ico',
-        '--exclude-module="config"',
+        '--exclude-module=config',
         '--name=twitchTransFN'
     ])

--- a/twitchTransFN.py
+++ b/twitchTransFN.py
@@ -58,7 +58,7 @@ synth_queue = queue.Queue()
 sound_queue = queue.Queue()
 
 # configure for Google TTS & play
-TMP_DIR = './tmp/'
+TMP_DIR = f'{os.path.dirname(sys.argv[0])}/tmp/'
 
 # translate.googleのサフィックスリスト
 URL_SUFFIX_LIST = [re.search('translate.google.(.*)', url.strip()).group(1) for url in constant.DEFAULT_SERVICE_URLS]


### PR DESCRIPTION
バイナリがM1 Macで実行できない問題はやはりアーキテクチャの違いによるもののようです。
GithubActionsで使用しているPythonもuniversal2について議論がされていますが、今のところ対応してないのでuniversal2のバイナリは作れないようです。
なのでローカルでも楽にビルドできるようにbuild.pyを追加しました。
依存関係とPyinstallerをインストールした状態で
```
python build.py
```
とすることでビルドできます。
GithubActionsもbuild.pyでバイナリを作成するように変更しました。

その他の修正
- MacではFinderから開くとカレントディレクトリがhomeに設定されてしまうのでそこにtmpと_MEIが作成されてしまいます。_MEIは変更できなかったですが、tmpはバイナリのディレクトリに作成されるようにしました。
- Pyinstallerのブートローダーをビルド時にビルドするようにしました。
  - これによりダウンロード時にWindowsDefenderに勝手にファイルが削除されてしまう問題を回避できたと思います(起動時の警告は出ます)
- GithubActionsで作成したMac用のファイルにIntelと付け加えました。

--runtime-tmpdirにバイナリのパスを渡すようなことができれば_MEI問題解決するんですが、まぁそこまでこだわることでもないかなーって気はします