### PR TITLE
特徴: メッセージを保存するデータベースとTwitch以外のエモートの削除

### DIFF
--- a/database_controller.py
+++ b/database_controller.py
@@ -6,37 +6,37 @@ ja : すべてのコメントはDeepLを使用して翻訳されました。
 
 import os, sqlite3, asyncio
 
-db_name = 'database.db'					# en:Filename of database		ja:データベースのファイル名
+db_name = 'database.db'						# en:Filename of database	ja:データベースのファイル名
 table_name = 'translations'
 cwd = os.getcwd()						# en:Current Working Directory 	ja:現在の作業フォルダ
-db_file = os.path.join(cwd,db_name)		# en:Database File				ja:データベース・ファイル
+db_file = os.path.join(cwd,db_name)				# en:Database File		ja:データベース・ファイル
 
-try:									# en:Create the database File	ja:データベース・ファイルの作成
-	with open(db_file, "x") as fp:		# "x" = en:"Create file"		ja:「ファイル作成」
+try:								# en:Create the database File	ja:データベース・ファイルの作成
+	with open(db_file, "x") as fp:				# "x" = en:"Create file"	ja:「ファイル作成」
 		pass
 	print("Database created.")
-except FileExistsError as e:			# en:Continue if file exists	ja:ファイルが存在する場合、続行
+except FileExistsError as e:					# en:Continue if file exists	ja:ファイルが存在する場合、続行
 	print(e)
 	pass
 
 db = sqlite3.connect(db_file)
 print("Connected to database.")
 
-try:									# en:Create translation table	ja:翻訳テーブルの作成
+try:								# en:Create translation table	ja:翻訳テーブルの作成
 	db.execute(f'''CREATE TABLE {table_name}
 		(ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 		MESSAGE TEXT NOT NULL,
 		TRANSLATION TEXT);''')
 	print("Table created.")
-except sqlite3.OperationalError as e:	# en:Continue if table exists	ja:テーブルが存在する場合、続行する
+except sqlite3.OperationalError as e:				# en:Continue if table exists	ja:テーブルが存在する場合、続行する
 	print(e)
 	pass
 
-async def save(message,translation):	# en:Save the translations		ja:翻訳を保存する
+async def save(message,translation):				# en:Save the translations	ja:翻訳を保存する
 	db.execute(f'INSERT INTO {table_name} (MESSAGE,TRANSLATION) VALUES (\"{message}\", \"{translation}\");')
 	db.commit()
 
-async def get(message):					# en:Get the translations		ja:翻訳を入手する
+async def get(message):						# en:Get the translations	ja:翻訳を入手する
 	# en:Return translation or None if nothing found	ja:翻訳を返すか、何も見つからなければ None を返す
 	return db.execute(f'SELECT TRANSLATION FROM {table_name} WHERE MESSAGE="{message}"').fetchone()
 

--- a/database_controller.py
+++ b/database_controller.py
@@ -6,38 +6,38 @@ ja : すべてのコメントはDeepLを使用して翻訳されました。
 
 import os, sqlite3, asyncio
 
-db_name = 'database.db'						# en:Filename of database	ja:データベースのファイル名
+db_name = 'database.db'					# en:Filename of database	ja:データベースのファイル名
 table_name = 'translations'
-cwd = os.getcwd()						# en:Current Working Directory 	ja:現在の作業フォルダ
-db_file = os.path.join(cwd,db_name)				# en:Database File		ja:データベース・ファイル
+cwd = os.getcwd()					# en:Current Working Directory 	ja:現在の作業フォルダ
+db_file = os.path.join(cwd,db_name)			# en:Database File		ja:データベース・ファイル
 
-try:								# en:Create the database File	ja:データベース・ファイルの作成
-	with open(db_file, "x") as fp:				# "x" = en:"Create file"	ja:「ファイル作成」
+try:							# en:Create the database File	ja:データベース・ファイルの作成
+	with open(db_file, "x") as fp:			# "x" = en:"Create file"	ja:「ファイル作成」
 		pass
 	print("Database created.")
-except FileExistsError as e:					# en:Continue if file exists	ja:ファイルが存在する場合、続行
+except FileExistsError as e:				# en:Continue if file exists	ja:ファイルが存在する場合、続行
 	print(e)
 	pass
 
 db = sqlite3.connect(db_file)
 print("Connected to database.")
 
-try:								# en:Create translation table	ja:翻訳テーブルの作成
+try:							# en:Create translation table	ja:翻訳テーブルの作成
 	db.execute(f'''CREATE TABLE {table_name}
 		(ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 		MESSAGE TEXT NOT NULL,
 		TRANSLATION TEXT);''')
 	print("Table created.")
-except sqlite3.OperationalError as e:				# en:Continue if table exists	ja:テーブルが存在する場合、続行する
+except sqlite3.OperationalError as e:			# en:Continue if table exists	ja:テーブルが存在する場合、続行する
 	print(e)
 	pass
 
-async def save(message,translation):				# en:Save the translations	ja:翻訳を保存する
+async def save(message,translation):			# en:Save the translations	ja:翻訳を保存する
 	db.execute(f'INSERT INTO {table_name} (MESSAGE,TRANSLATION) VALUES (\"{message}\", \"{translation}\");')
 	db.commit()
 
-async def get(message):						# en:Get the translations	ja:翻訳を入手する
-	# en:Return translation or None if nothing found	ja:翻訳を返すか、何も見つからなければ None を返す
+async def get(message):					# en:Get the translations	ja:翻訳を入手する
+	# en:Return translation or None if nothing found    ja:翻訳を返すか、何も見つからなければ None を返す
 	return db.execute(f'SELECT TRANSLATION FROM {table_name} WHERE MESSAGE="{message}"').fetchone()
 
 def close():

--- a/database_controller.py
+++ b/database_controller.py
@@ -1,0 +1,44 @@
+'''
+en : All comments were translated using DeepL.
+ja : すべてのコメントはDeepLを使用して翻訳されました。
+
+'''
+
+import os, sqlite3, asyncio
+
+db_name = 'database.db'					# en:Filename of database		ja:データベースのファイル名
+table_name = 'translations'
+cwd = os.getcwd()						# en:Current Working Directory 	ja:現在の作業フォルダ
+db_file = os.path.join(cwd,db_name)		# en:Database File				ja:データベース・ファイル
+
+try:									# en:Create the database File	ja:データベース・ファイルの作成
+	with open(db_file, "x") as fp:		# "x" = en:"Create file"		ja:「ファイル作成」
+		pass
+	print("Database created.")
+except FileExistsError as e:			# en:Continue if file exists	ja:ファイルが存在する場合、続行
+	print(e)
+	pass
+
+db = sqlite3.connect(db_file)
+print("Connected to database.")
+
+try:									# en:Create translation table	ja:翻訳テーブルの作成
+	db.execute(f'''CREATE TABLE {table_name}
+		(ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+		MESSAGE TEXT NOT NULL,
+		TRANSLATION TEXT);''')
+	print("Table created.")
+except sqlite3.OperationalError as e:	# en:Continue if table exists	ja:テーブルが存在する場合、続行する
+	print(e)
+	pass
+
+async def save(message,translation):	# en:Save the translations		ja:翻訳を保存する
+	db.execute(f'INSERT INTO {table_name} (MESSAGE,TRANSLATION) VALUES (\"{message}\", \"{translation}\");')
+	db.commit()
+
+async def get(message):					# en:Get the translations		ja:翻訳を入手する
+	# en:Return translation or None if nothing found	ja:翻訳を返すか、何も見つからなければ None を返す
+	return db.execute(f'SELECT TRANSLATION FROM {table_name} WHERE MESSAGE="{message}"').fetchone()
+
+def close():
+	db.close()

--- a/twitchTransFN.py
+++ b/twitchTransFN.py
@@ -391,6 +391,7 @@ class Bot(commands.Bot):
 
         await msg.channel.send("/me " + out_text)
 
+        # en:Save the translation to database   ja:翻訳をデータベースに保存する
         if translation_from_database is None:
             await db.save(in_text,translatedText)
 

--- a/twitchTransFN.py
+++ b/twitchTransFN.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from async_google_trans_new import AsyncTranslator, constant
 from http.client import HTTPSConnection as hc
 from gtts import gTTS


### PR DESCRIPTION
# [2.5.2](https://github.com/didotb/twitchTransFreeNext/commits/v2.5.2)
+ ## Removal of non-Twitch emotes
  Removal of BetterTTV, 7TV, and FrankerFaceZ emotes as requested at #48 
+ ## メッセージからTwitch以外のエモートを削除
  #48 で要望のあったBetterTTV、7TV、FrankerFaceZのエモートの削除。

#

# [2.5.1](https://github.com/didotb/twitchTransFreeNext/commits/v2.5.1)
+ ## Use SQLite database to reduce DeepL limit 
  The bot sometimes breaks when using DeepL for long periods because of DeepL word limit per 24 hours.

  In order to prevent this I added a feature which the bot will check the local database first if the message was already translated, and use the translation from the database.

  If however, the message wasn't found in the database, it will function normally as it did back then, then save the translation to the database for future use.
  + ### Note
    + It is important to know the database will slowly use more storage and must be deleted when it gets too big.

+ ## SQLiteデータベースを使用してDeepLの制限を軽減 
  DeepLを長時間使用すると、DeepLの24時間あたりの単語数制限のため、ボットが壊れることがある。

  これを防ぐために、メッセージがすでに翻訳されている場合は、ボットがまずローカルのデータベースをチェックし、データベースからの翻訳を使用する機能を追加しました。

  しかし、そのメッセージがデータベースで見つからなかった場合は、当時と同じように機能し、その後、将来の使用のために翻訳をデータベースに保存します。
  + ### 備考
    + データベースは徐々にストレージを使用するようになり、大きくなり過ぎると削除しなければならないことを知っておくことが重要です。