### PR TITLE
DeepLが無料翻訳の単語制限に達しないようにするためのアップデートです。

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,18 +35,8 @@ jobs:
         with:
           python-version: "3.10"
 
-      - name: upgrade pip
-        run: python -m pip install --upgrade pip setuptools wheel
-
-      - name: build pyinstaller
-        continue-on-error: true
-        run: |
-          git clone https://github.com/pyinstaller/pyinstaller
-          cd ./pyinstaller/bootloader
-          python ./waf distclean all
-          cd ../
-          python setup.py install
-          cd ../
+      - name: upgrade pip and install PyInstaller
+        run: python -m pip install --upgrade pip setuptools wheel pyinstaller
 
       - name: install requirements
         run: python -m pip install -r requirements.txt

--- a/config.py
+++ b/config.py
@@ -1,39 +1,43 @@
 ######################################################
 # PLEASE CHANGE FOLLOWING CONFIGS ####################
-Twitch_Channel          = 'target_channel_name'
+Twitch_Channel          = 'DdotB'
 
-Trans_Username          = 'trans_user_name'
-Trans_OAUTH             = 'oauth_for_trans_user'
+Trans_Username          = 'DeeBeeTTV'
+#Trans_Username          = 'ddotb'
+Trans_OAUTH             = 'oauth:mqnrbkcxpowouryog1gts78m9q15mj'
+#Trans_OAUTH             = 'oauth:asrboztzet3ybctrrun47rnlfhhbs5'
 
 #######################################################
 # OPTIONAL CONFIGS ####################################
-Trans_TextColor         = 'GoldenRod'
+Trans_TextColor         = 'CadetBlue'
 # Blue, Coral, DodgerBlue, SpringGreen, YellowGreen, Green, OrangeRed, Red, GoldenRod, HotPink, CadetBlue, SeaGreen, Chocolate, BlueViolet, and Firebrick
 
 lang_TransToHome        = 'ja'
 lang_HomeToOther        = 'en'
 
-Show_ByName             = True
+Show_ByName             = False
 Show_ByLang             = True
 
 Ignore_Lang             = ['']
-Ignore_Users            = ['Nightbot', 'BikuBikuTest']
+Ignore_Users            = ['Nightbot', 'BikuBikuTest', 'halo_trans', 'streamelements', 'streamlabs', 'sery_bot', 'beaneyboobutler', 'ministerofforeignaffairs', 'PokemonCommunityGame']
 Ignore_Line             = ['http', 'BikuBikuTest', '888', '８８８']
 Delete_Words            = ['saatanNooBow', 'BikuBikuTest']
 
 # Any emvironment, set it to `True`, then text will be read by TTS voice!
 # TTS_In:User Input Text, TTS_Out:Bot Output Text
-TTS_In                  = True
+TTS_In                  = False
 TTS_Out                 = True
 TTS_Kind                = "gTTS" # You can choice "CeVIO" if you want to use CeVIO as TTS.
 # CeVIO_Cast            = "さとうささら" # When you are using CeVIO, you must set voice cast name.
+TTS_TextMaxLength		= 10
+TTS_MessageForOmitting = "以下略"
 
 # if you make TTS for only few lang, please add langID in the list
 # for example, ['ja'] means Japanese only, ['ko','en'] means Korean and English are TTS!
 ReadOnlyTheseLang       = []
 
 # Select the translate engine ('deepl' or 'google')
-Translator              = 'google'
+Translator              = 'deepl'
 
 # Use Google Apps Script for tlanslating
 # e.g.) GAS_URL         = 'https://script.google.com/macros/s/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/exec'

--- a/database_controller.py
+++ b/database_controller.py
@@ -6,37 +6,37 @@ ja : すべてのコメントはDeepLを使用して翻訳されました。
 
 import os, sqlite3, asyncio
 
-db_name = 'database.db'					# en:Filename of database		ja:データベースのファイル名
+db_name = 'database.db'						# en:Filename of database	ja:データベースのファイル名
 table_name = 'translations'
 cwd = os.getcwd()						# en:Current Working Directory 	ja:現在の作業フォルダ
-db_file = os.path.join(cwd,db_name)		# en:Database File				ja:データベース・ファイル
+db_file = os.path.join(cwd,db_name)				# en:Database File		ja:データベース・ファイル
 
-try:									# en:Create the database File	ja:データベース・ファイルの作成
-	with open(db_file, "x") as fp:		# "x" = en:"Create file"		ja:「ファイル作成」
+try:								# en:Create the database File	ja:データベース・ファイルの作成
+	with open(db_file, "x") as fp:				# "x" = en:"Create file"	ja:「ファイル作成」
 		pass
 	print("Database created.")
-except FileExistsError as e:			# en:Continue if file exists	ja:ファイルが存在する場合、続行
+except FileExistsError as e:					# en:Continue if file exists	ja:ファイルが存在する場合、続行
 	print(e)
 	pass
 
 db = sqlite3.connect(db_file)
 print("Connected to database.")
 
-try:									# en:Create translation table	ja:翻訳テーブルの作成
+try:								# en:Create translation table	ja:翻訳テーブルの作成
 	db.execute(f'''CREATE TABLE {table_name}
 		(ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 		MESSAGE TEXT NOT NULL,
 		TRANSLATION TEXT);''')
 	print("Table created.")
-except sqlite3.OperationalError as e:	# en:Continue if table exists	ja:テーブルが存在する場合、続行する
+except sqlite3.OperationalError as e:				# en:Continue if table exists	ja:テーブルが存在する場合、続行する
 	print(e)
 	pass
 
-async def save(message,translation):	# en:Save the translations		ja:翻訳を保存する
+async def save(message,translation):				# en:Save the translations	ja:翻訳を保存する
 	db.execute(f'INSERT INTO {table_name} (MESSAGE,TRANSLATION) VALUES (\"{message}\", \"{translation}\");')
 	db.commit()
 
-async def get(message):					# en:Get the translations		ja:翻訳を入手する
+async def get(message):						# en:Get the translations	ja:翻訳を入手する
 	# en:Return translation or None if nothing found	ja:翻訳を返すか、何も見つからなければ None を返す
 	return db.execute(f'SELECT TRANSLATION FROM {table_name} WHERE MESSAGE="{message}"').fetchone()
 

--- a/database_controller.py
+++ b/database_controller.py
@@ -6,38 +6,38 @@ ja : すべてのコメントはDeepLを使用して翻訳されました。
 
 import os, sqlite3, asyncio
 
-db_name = 'database.db'						# en:Filename of database	ja:データベースのファイル名
+db_name = 'database.db'					# en:Filename of database	ja:データベースのファイル名
 table_name = 'translations'
-cwd = os.getcwd()						# en:Current Working Directory 	ja:現在の作業フォルダ
-db_file = os.path.join(cwd,db_name)				# en:Database File		ja:データベース・ファイル
+cwd = os.getcwd()					# en:Current Working Directory 	ja:現在の作業フォルダ
+db_file = os.path.join(cwd,db_name)			# en:Database File		ja:データベース・ファイル
 
-try:								# en:Create the database File	ja:データベース・ファイルの作成
-	with open(db_file, "x") as fp:				# "x" = en:"Create file"	ja:「ファイル作成」
+try:							# en:Create the database File	ja:データベース・ファイルの作成
+	with open(db_file, "x") as fp:			# "x" = en:"Create file"	ja:「ファイル作成」
 		pass
 	print("Database created.")
-except FileExistsError as e:					# en:Continue if file exists	ja:ファイルが存在する場合、続行
+except FileExistsError as e:				# en:Continue if file exists	ja:ファイルが存在する場合、続行
 	print(e)
 	pass
 
 db = sqlite3.connect(db_file)
 print("Connected to database.")
 
-try:								# en:Create translation table	ja:翻訳テーブルの作成
+try:							# en:Create translation table	ja:翻訳テーブルの作成
 	db.execute(f'''CREATE TABLE {table_name}
 		(ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 		MESSAGE TEXT NOT NULL,
 		TRANSLATION TEXT);''')
 	print("Table created.")
-except sqlite3.OperationalError as e:				# en:Continue if table exists	ja:テーブルが存在する場合、続行する
+except sqlite3.OperationalError as e:			# en:Continue if table exists	ja:テーブルが存在する場合、続行する
 	print(e)
 	pass
 
-async def save(message,translation):				# en:Save the translations	ja:翻訳を保存する
+async def save(message,translation):			# en:Save the translations	ja:翻訳を保存する
 	db.execute(f'INSERT INTO {table_name} (MESSAGE,TRANSLATION) VALUES (\"{message}\", \"{translation}\");')
 	db.commit()
 
-async def get(message):						# en:Get the translations	ja:翻訳を入手する
-	# en:Return translation or None if nothing found	ja:翻訳を返すか、何も見つからなければ None を返す
+async def get(message):					# en:Get the translations	ja:翻訳を入手する
+	# en:Return translation or None if nothing found    ja:翻訳を返すか、何も見つからなければ None を返す
 	return db.execute(f'SELECT TRANSLATION FROM {table_name} WHERE MESSAGE="{message}"').fetchone()
 
 def close():

--- a/database_controller.py
+++ b/database_controller.py
@@ -6,39 +6,39 @@ ja : すべてのコメントはDeepLを使用して翻訳されました。
 
 import os, sqlite3, asyncio
 
-db_name = 'database.db'					# en:Filename of database	ja:データベースのファイル名
+db_name = 'database.db'					# en:Filename of database		ja:データベースのファイル名
 table_name = 'translations'
-cwd = os.getcwd()					# en:Current Working Directory 	ja:現在の作業フォルダ
-db_file = os.path.join(cwd,db_name)			# en:Database File		ja:データベース・ファイル
+cwd = os.getcwd()						# en:Current Working Directory 	ja:現在の作業フォルダ
+db_file = os.path.join(cwd,db_name)		# en:Database File				ja:データベース・ファイル
 
-try:							# en:Create the database File	ja:データベース・ファイルの作成
-	with open(db_file, "x") as fp:			# "x" = en:"Create file"	ja:「ファイル作成」
+try:									# en:Create the database File	ja:データベース・ファイルの作成
+	with open(db_file, "x") as fp:		# "x" = en:"Create file"		ja:「ファイル作成」
 		pass
 	print("Database created.")
-except FileExistsError as e:				# en:Continue if file exists	ja:ファイルが存在する場合、続行
-	print(e)
+except FileExistsError as e:			# en:Continue if file exists	ja:ファイルが存在する場合、続行
 	pass
 
 db = sqlite3.connect(db_file)
 print("Connected to database.")
 
-try:							# en:Create translation table	ja:翻訳テーブルの作成
+try:									# en:Create translation table	ja:翻訳テーブルの作成
 	db.execute(f'''CREATE TABLE {table_name}
 		(ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 		MESSAGE TEXT NOT NULL,
+		DLANG TEXT NOT NULL,
 		TRANSLATION TEXT);''')
 	print("Table created.")
-except sqlite3.OperationalError as e:			# en:Continue if table exists	ja:テーブルが存在する場合、続行する
+except sqlite3.OperationalError as e:  # en:Continue if table exists   ja:テーブルが存在する場合、続行する
 	print(e)
 	pass
 
-async def save(message,translation):			# en:Save the translations	ja:翻訳を保存する
-	db.execute(f'INSERT INTO {table_name} (MESSAGE,TRANSLATION) VALUES (\"{message}\", \"{translation}\");')
+async def save(message,translation,dlang):	# en:Save the translations   ja:翻訳を保存する
+	db.execute(f'INSERT INTO {table_name} (MESSAGE,DLANG,TRANSLATION) VALUES (\"{message}\", \"{dlang}\", \"{translation}\");')
 	db.commit()
 
-async def get(message):					# en:Get the translations	ja:翻訳を入手する
-	# en:Return translation or None if nothing found    ja:翻訳を返すか、何も見つからなければ None を返す
-	return db.execute(f'SELECT TRANSLATION FROM {table_name} WHERE MESSAGE="{message}"').fetchone()
+async def get(message,dlang):  # en:Get the translations    ja:翻訳を入手する
+	# en:Return translation or None if nothing found   ja:翻訳を返すか、何も見つからなければ None を返す
+	return db.execute(f'SELECT TRANSLATION FROM {table_name} WHERE MESSAGE="{message}" AND DLANG="{dlang}"').fetchone()
 
 def delete(target_size:int = 52428800):
 	size = os.path.getsize(db_file)

--- a/database_controller.py
+++ b/database_controller.py
@@ -1,0 +1,44 @@
+'''
+en : All comments were translated using DeepL.
+ja : すべてのコメントはDeepLを使用して翻訳されました。
+
+'''
+
+import os, sqlite3, asyncio
+
+db_name = 'database.db'					# en:Filename of database		ja:データベースのファイル名
+table_name = 'translations'
+cwd = os.getcwd()						# en:Current Working Directory 	ja:現在の作業フォルダ
+db_file = os.path.join(cwd,db_name)		# en:Database File				ja:データベース・ファイル
+
+try:									# en:Create the database File	ja:データベース・ファイルの作成
+	with open(db_file, "x") as fp:		# "x" = en:"Create file"		ja:「ファイル作成」
+		pass
+	print("Database created.")
+except FileExistsError as e:			# en:Continue if file exists	ja:ファイルが存在する場合、続行
+	print(e)
+	pass
+
+db = sqlite3.connect(db_file)
+print("Connected to database.")
+
+try:									# en:Create translation table	ja:翻訳テーブルの作成
+	db.execute(f'''CREATE TABLE {table_name}
+		(ID INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+		MESSAGE TEXT NOT NULL,
+		TRANSLATION TEXT);''')
+	print("Table created.")
+except sqlite3.OperationalError as e:	# en:Continue if table exists	ja:テーブルが存在する場合、続行する
+	print(e)
+	pass
+
+async def save(message,translation):	# en:Save the translations		ja:翻訳を保存する
+	db.execute(f'INSERT INTO {table_name} (MESSAGE,TRANSLATION) VALUES (\"{message}\", \"{translation}\");')
+	db.commit()
+
+async def get(message):					# en:Get the translations		ja:翻訳を入手する
+	# en:Return translation or None if nothing found	ja:翻訳を返すか、何も見つからなければ None を返す
+	return db.execute(f'SELECT TRANSLATION FROM {table_name} WHERE MESSAGE="{message}"').fetchone()
+
+def close():
+	db.close()

--- a/database_controller.py
+++ b/database_controller.py
@@ -40,5 +40,10 @@ async def get(message):					# en:Get the translations	ja:翻訳を入手する
 	# en:Return translation or None if nothing found    ja:翻訳を返すか、何も見つからなければ None を返す
 	return db.execute(f'SELECT TRANSLATION FROM {table_name} WHERE MESSAGE="{message}"').fetchone()
 
+def delete(target_size:int = 52428800):
+	size = os.path.getsize(db_file)
+	if size >= target_size:
+		os.remove(db_file)
+
 def close():
 	db.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ playsound==1.2.2
 deepl-translate==1.2.0
 twitchio==2.3.0
 pywin32;platform_system == 'Windows'
+emoji==2.2.0

--- a/sound.py
+++ b/sound.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from playsound import playsound
+import time
+import threading
+import queue
+
+class Sound:
+    def __init__(self, config):
+        self.config = config
+        self.sound_queue = queue.Queue()
+
+    def run(self):
+        if self.config.Debug: print("run, sound play thread...")
+        thread_sound = threading.Thread(target=self.sound_play)
+        thread_sound.start()
+
+    def put(self, obj):
+        self.sound_queue.put(obj)
+
+    #####################################
+    # !sound 音声再生スレッド -------------
+    def sound_play(self):
+        while True:
+            q = self.sound_queue.get()
+            if q is None:
+                time.sleep(1)
+            else:
+                try:
+                    playsound('./sound/{}.mp3'.format(q), True)
+                except Exception as e:
+                    print('sound error: [!sound] command can not play sound...')
+                    if self.config.Debug: print(e.args)

--- a/tts.py
+++ b/tts.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from gtts import gTTS
+from playsound import playsound
+from datetime import datetime
+import time
+import os
+import queue
+import threading
+
+class TTS:
+    """
+    TTS(Text To Speach)を取り扱うクラス
+    putされた文面をスレッドで処理し、
+    必要な加工を施した上で適切なタイミングで読み上げる
+    """
+
+    def __init__(self, config):
+        self.config = config
+        self.synth_queue = queue.Queue()
+
+    def put(self, text, lang):
+        self.synth_queue.put([text, lang])
+
+    def run(self):
+        if self.config.Debug: print("run, voice synth thread...")
+        if self.config.TTS_In or self.config.TTS_Out:
+            thread_voice = threading.Thread(target=self.voice_synth)
+            thread_voice.start()
+
+    # TTS向けのコメントをコンフィグに応じて短縮する
+    # もし長過ぎる文面だった場合、省略し、末尾に省略を意味する読み上げを追加する。
+    # そうでない場合は、もとのテキストのままとなる。
+    def shorten_tts_comment(self, comment):
+        maxlen = self.config.TTS_TextMaxLength
+        if maxlen == 0:
+            return comment
+        if len(comment) <= maxlen:
+            return comment
+        return f"{comment[0:maxlen]} {self.config.TTS_MessageForOmitting}"
+
+
+    # CeVIOを呼び出すための関数を生成する関数
+    # つまり cast 引数を与えることで、この関数から
+    # 該当のCeVIOキャストにより音声再生を行える関数が帰ってきます。
+    # 例("さとうささら"に"ささらちゃん読み上げて！"を読ませる呼び出し):
+    #   f = CeVIO("さとうささら")
+    #   f("ささらちゃん読み上げて！", "ja")
+    # TODO: ただし第二引数(tl)は現状実装されていないため、
+    # 該当キャストのデフォルト言語で読み上げは行われます。
+    def CeVIO(self, cast):
+        # CeVIOとそれを呼び出すためのWin32COMの仕組みはWindowsにしかありません。
+        # そこでこのCeVIO関数内にimport実行を閉じることで
+        # ライブラリの不在を回避して他環境と互換させます。
+        import win32com.client
+        import pythoncom
+        pythoncom.CoInitialize()
+        cevio = win32com.client.Dispatch("CeVIO.Talk.RemoteService2.ServiceControl2")
+        cevio.StartHost(False)
+        talker = win32com.client.Dispatch("CeVIO.Talk.RemoteService2.Talker2V40")
+        talker.Cast = cast
+        # in this routine, we will omit tl because CeVIO doesn't support language paramter.
+        def play(text, _):
+            try:
+                state = talker.Speak(text)
+                if self.config.Debug: print(f"text '{text}' has dispatched to CeVIO.")
+                state.Wait()
+            except Exception as e:
+                print('CeVIO error: TTS sound is not generated...')
+                if self.config.Debug: print(e.args)
+        return play
+
+
+    # gTTSを利用して
+    # 音声合成 ＆ ファイル保存 ＆ ファイル削除
+    # までを行う音声合成の実行関数。
+    def gTTS_play(self, text, tl):
+        try:
+            tts = gTTS(text, lang=tl)
+            tts_file = './tmp/cnt_{}.mp3'.format(datetime.now().microsecond)
+            if self.config.Debug: print('gTTS file: {}'.format(tts_file))
+            tts.save(tts_file)
+            playsound(tts_file, True)
+            os.remove(tts_file)
+        except Exception as e:
+            print('gTTS error: TTS sound is not generated...')
+            if self.config.Debug: print(e.args)
+
+
+    # どのTextToSpeechを利用するかをconfigから選択して再生用の関数を返す
+    def Determine_TTS(self):
+        kind = self.config.TTS_Kind.strip().upper()
+        if kind == "CeVIO".upper():
+            return self.CeVIO(self.config.CeVIO_Cast)
+        else:
+            return self.gTTS_play
+
+
+    # 音声合成(TTS)の待ち受けスレッド
+    # このスレッドにより各音声合成(TTS)が起動して音声読み上げされます。
+    # このスレッドに対するメッセージ入力は
+    # グローバルに定義されたsynth_queueを介して行います。
+    def voice_synth(self):
+        tts = self.Determine_TTS()
+        while True:
+            q = self.synth_queue.get()
+            if q is None:
+                time.sleep(1)
+            else:
+                text    = q[0]
+                tl      = q[1]
+
+                if self.config.Debug: print('debug in Voice_Thread')
+                if self.config.Debug: print(f'config.ReadOnlyTheseLang : {self.config.ReadOnlyTheseLang}')
+                if self.config.Debug: print(f'tl not in config.ReadOnlyTheseLang : {tl not in self.config.ReadOnlyTheseLang}')
+
+                # 「この言語だけ読み上げて」リストが空じゃなく，なおかつそのリストにに入ってなかったら無視
+                if self.config.ReadOnlyTheseLang and (tl not in self.config.ReadOnlyTheseLang):
+                    continue
+
+                text = self.shorten_tts_comment(text)
+                tts(text, tl)

--- a/twitchTransFN.py
+++ b/twitchTransFN.py
@@ -606,3 +606,4 @@ if __name__ == "__main__":
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     main()
     db.close()
+    db.delete()

--- a/twitchTransFN.py
+++ b/twitchTransFN.py
@@ -7,6 +7,7 @@ from gtts import gTTS
 from playsound import playsound
 from datetime import datetime
 from twitchio.ext import commands
+from emoji import distinct_emoji_list
 import json
 import os
 import threading
@@ -71,7 +72,6 @@ TargetLangs = ["af", "sq", "am", "ar", "hy", "az", "eu", "be", "bn", "bs", "bg",
                 "sv", "tg", "ta", "te", "th", "tr", "uk", "ur", "uz", "vi", "cy", "xh", "yi", "yo", "zu"]
 
 deepl_lang_dict = {'de':'DE', 'en':'EN', 'fr':'FR', 'es':'ES', 'pt':'PT', 'it':'IT', 'nl':'NL', 'pl':'PL', 'ru':'RU', 'ja':'JA', 'zh-CN':'ZH'}
-
 
 ##########################################
 # load config text #######################
@@ -253,8 +253,14 @@ class Bot(commands.Bot):
 
         # en:Remove non-Twitch emotes from message     ja:メッセージからTwitch以外のエモートを削除
         temp_msg = message.split(' ')
+        # en:Place non-Twitch emotes in temporary variable  ja:Twitch以外のエモートを一時的な変数に配置する。
         nte = list(set(non_twitch_emote_list) & set(temp_msg)) # nte = "non-Twitch emotes"
         for i in nte:
+            if config.Debug: print(i)
+            emote_list.append(i)
+        # en:Place unicode emoji in temporary variable  ja:ユニコード絵文字をテンポラリ変数に入れる
+        uEmoji = distinct_emoji_list(message) # uEmoji = "Unicode Emoji"
+        for i in uEmoji:
             if config.Debug: print(i)
             emote_list.append(i)
 

--- a/twitchTransFN.py
+++ b/twitchTransFN.py
@@ -3,23 +3,10 @@
 
 from async_google_trans_new import AsyncTranslator, constant
 from http.client import HTTPSConnection as hc
-from gtts import gTTS
-from playsound import playsound
-from datetime import datetime
 from twitchio.ext import commands
 from emoji import distinct_emoji_list
-import json
-import os
-import threading
-import queue
-import time
-import shutil
-import re
-import database_controller as db # ja:既訳語データベース (en:Translation Database)
-import asyncio
-import deepl
-import sys
-import signal
+import json, os, shutil, re, asyncio, deepl, sys, signal, tts, sound
+import database_controller as db # ja:既訳語データベース   en:Translation Database
 
 version = '2.5.1'
 '''
@@ -54,9 +41,6 @@ v2.0.3  : いろいろ実装した
 
 #####################################
 # 初期設定 ###########################
-
-synth_queue = queue.Queue()
-sound_queue = queue.Queue()
 
 # configure for Google TTS & play
 TMP_DIR = f'{os.path.dirname(sys.argv[0])}/tmp/'
@@ -124,6 +108,8 @@ else:
     url_suffix = 'co.jp'
 
 translator = AsyncTranslator(url_suffix=url_suffix)
+tts = tts.TTS(config)
+sound = sound.Sound(config)
 
 ##########################################
 # 関連関数 ################################
@@ -336,7 +322,7 @@ class Bot(commands.Bot):
         # 音声合成（入力文） --------------
         # if len(in_text) > int(config.TooLong_Cut):
         #     in_text = in_text[0:int(config.TooLong_Cut)]
-        if config.TTS_In: synth_queue.put([in_text, lang_detect])
+        if config.TTS_In: tts.put(in_text, lang_detect)
 
         # 検出言語と翻訳先言語が同じだったら無視！
         if lang_detect == lang_dest:
@@ -423,7 +409,7 @@ class Bot(commands.Bot):
         # 音声合成（出力文） --------------
         # if len(translatedText) > int(config.TooLong_Cut):
         #     translatedText = translatedText[0:int(config.TooLong_Cut)]
-        if config.TTS_Out: synth_queue.put([translatedText, lang_dest])
+        if config.TTS_Out: tts.put(translatedText, lang_dest)
 
 
     ##############################
@@ -435,7 +421,7 @@ class Bot(commands.Bot):
     @commands.command(name='sound')
     async def sound(self, ctx):
         sound_name = ctx.message.content.strip().split(" ")[1]
-        sound_queue.put(sound_name)
+        sound.put(sound_name)
 
     @commands.command(name='timer')
     async def timer(self, ctx):
@@ -468,101 +454,6 @@ class Bot(commands.Bot):
         await asyncio.sleep(timer_min*60)
         await ctx.send(f'#### timer [{timer_name}] ({timer_min} min.) end! ####')
 
-# CeVIOを呼び出すための関数を生成する関数
-# つまり cast 引数を与えることで、この関数から
-# 該当のCeVIOキャストにより音声再生を行える関数が帰ってきます。
-# 例("さとうささら"に"ささらちゃん読み上げて！"を読ませる呼び出し):
-#   f = CeVIO("さとうささら")
-#   f("ささらちゃん読み上げて！", "ja")
-# TODO: ただし第二引数(tl)は現状実装されていないため、
-# 該当キャストのデフォルト言語で読み上げは行われます。
-def CeVIO(cast):
-    # CeVIOとそれを呼び出すためのWin32COMの仕組みはWindowsにしかありません。
-    # そこでこのCeVIO関数内にimport実行を閉じることで
-    # ライブラリの不在を回避して他環境と互換させます。
-    import win32com.client
-    import pythoncom
-    pythoncom.CoInitialize()
-    cevio = win32com.client.Dispatch("CeVIO.Talk.RemoteService2.ServiceControl2")
-    cevio.StartHost(False)
-    talker = win32com.client.Dispatch("CeVIO.Talk.RemoteService2.Talker2V40")
-    talker.Cast = cast
-    # in this routine, we will omit tl because CeVIO doesn't support language paramter.
-    def play(text, _):
-        try:
-            state = talker.Speak(text)
-            if config.Debug: print(f"text '{text}' has dispatched to CeVIO.")
-            state.Wait()
-        except Exception as e:
-            print('CeVIO error: TTS sound is not generated...')
-            if config.Debug: print(e.args)
-    return play
-
-# gTTSを利用して
-# 音声合成 ＆ ファイル保存 ＆ ファイル削除
-# までを行う音声合成の実行関数。
-def gTTS_play(text, tl):
-    try:
-        tts = gTTS(text, lang=tl)
-        tts_file = './tmp/cnt_{}.mp3'.format(datetime.now().microsecond)
-        if config.Debug: print('gTTS file: {}'.format(tts_file))
-        tts.save(tts_file)
-        playsound(tts_file, True)
-        os.remove(tts_file)
-    except Exception as e:
-        print('gTTS error: TTS sound is not generated...')
-        if config.Debug: print(e.args)
-
-# 音声合成(TTS)の待ち受けスレッド
-# このスレッドにより各音声合成(TTS)が起動して音声読み上げされます。
-# このスレッドに対するメッセージ入力は
-# グローバルに定義されたsynth_queueを介して行います。
-def voice_synth():
-    global synth_queue
-
-    tts = Determine_TTS()
-    while True:
-        q = synth_queue.get()
-        if q is None:
-            time.sleep(1)
-        else:
-            text    = q[0]
-            tl      = q[1]
-
-            if config.Debug: print('debug in Voice_Thread')
-            if config.Debug: print(f'config.ReadOnlyTheseLang : {config.ReadOnlyTheseLang}')
-            if config.Debug: print(f'tl not in config.ReadOnlyTheseLang : {tl not in config.ReadOnlyTheseLang}')
-
-            # 「この言語だけ読み上げて」リストが空じゃなく，なおかつそのリストにに入ってなかったら無視
-            if config.ReadOnlyTheseLang and (tl not in config.ReadOnlyTheseLang):
-                continue
-
-            tts(text, tl)
-
-# どのTextToSpeechを利用するかをconfigから選択して再生用の関数を返す
-def Determine_TTS():
-    kind = config.TTS_Kind.strip().upper()
-    if kind == "CeVIO".upper():
-        return CeVIO(config.CeVIO_Cast)
-    else:
-        return gTTS_play
-
-#####################################
-# !sound 音声再生スレッド -------------
-def sound_play():
-    global sound_queue
-
-    while True:
-        q = sound_queue.get()
-        if q is None:
-            time.sleep(1)
-        else:
-            try:
-                playsound('./sound/{}.mp3'.format(q), True)
-            except Exception as e:
-                print('sound error: [!sound] command can not play sound...')
-                if config.Debug: print(e.args)
-
 # メイン処理 ###########################
 def main():
     try:
@@ -587,15 +478,10 @@ def main():
         if config.Debug: print("made tmp dir.")
 
         # 音声合成スレッド起動 ################
-        if config.Debug: print("run, voice synth thread...")
-        if config.TTS_In or  config.TTS_Out:
-            thread_voice = threading.Thread(target=voice_synth)
-            thread_voice.start()
+        tts.run()
 
         # 音声再生スレッド起動 ################
-        if config.Debug: print("run, sound play thread...")
-        thread_sound = threading.Thread(target=sound_play)
-        thread_sound.start()
+        sound.run()
 
         # bot
         bot = Bot()

--- a/twitchTransFN.py
+++ b/twitchTransFN.py
@@ -391,6 +391,7 @@ class Bot(commands.Bot):
 
         await msg.channel.send("/me " + out_text)
 
+        # en:Save the translation to database   ja:翻訳をデータベースに保存する
         if translation_from_database is None:
             await db.save(in_text,translatedText)
 

--- a/twitchTransFN.py
+++ b/twitchTransFN.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from async_google_trans_new import AsyncTranslator, constant
 from http.client import HTTPSConnection as hc
 from gtts import gTTS


### PR DESCRIPTION
# [2.5.1_3](https://github.com/didotb/twitchTransFreeNext/commits/v2.5.1_3)
+ ## Updated following yuniruyuni changes
  Updated following yuniruyuni's changes to sound and tts module.
  Reference: sayonari#57

+ ## @yuniruyuni さんの変更に伴い、更新しました。
  @yuniruyuni さんによるサウンドとttsモジュールの変更に伴い更新しました。
  参考: sayonari#57

#

# [2.5.1_2](https://github.com/didotb/twitchTransFreeNext/commits/v2.5.1_2)
+ ## Database
  Database design was changed, it's important to remove the previous database file.
+ ## Translation
  Previously, even with emote removal, even empty messages are sent to translator to be translated. This defeats the purpose of version [2.5.0_1](https://github.com/didotb/twitchTransFreeNext/commits/v2.5.0_1). In this update, this unwanted behaviour has been changed, not only to DeepL but to Google Translate and GAS as well.
+ ## Security
  Since version [2.5.0_1](https://github.com/didotb/twitchTransFreeNext/commits/v2.5.0_1), the database controller prints out the full path location of the database file. There will be times when streamers uses their real name on their Windows Username while hoping to avoid revealing their real name on stream. This is a security risk for them; and I completely missed this during testing due to the amount of debug outputs, in addition to my focus on the source of the translation. This version should remove that.
+ ## Future plans
  I'm hoping I could add a notification on the console window if there are any updates to @sayonari 's code or to mine. Although, this won't be a priority so don't expect it in the next update.

+ ## データベース
  データベースの設計が変更されたので、以前のデータベースファイルを削除することが重要です。
+ ## 翻訳
  以前は、エモート削除をしても、空のメッセージでも翻訳者に送られて翻訳されていました。これはバージョン[2.5.0_1](https://github.com/didotb/twitchTransFreeNext/commits/v2.5.0_1)の目的を逸脱しています。今回のアップデートでは、DeepLだけでなく、Google翻訳やGASでもこの不要な動作が変更されました。
+ ## セキュリティ
  バージョン[2.5.0_1](https://github.com/didotb/twitchTransFreeNext/commits/v2.5.0_1)から、データベースコントローラは、データベースファイルのフルパス位置を表示するようになりました。ストリーマーが、ストリーム上で本名を明かさないようにと思いながら、Windowsのユーザー名で本名を使うことがあります。これは彼らにとってセキュリティリスクであり、私はテスト中、デバッグ出力の多さと翻訳元への集中のために、これを完全に見逃していました。このバージョンでは、これを取り除く必要があります。
+ ## 今後の予定
  @sayonari のコードや私のコードに更新があった場合、コンソールウィンドウに通知を追加できればと思っています。しかし、これは優先順位が低いので、次のアップデートでは期待しないでください。

#

# [2.5.1_1](https://github.com/didotb/twitchTransFreeNext/commits/v2.5.1_1)
+ ## Removal of unicode emoji
  Removed Unicode Emojis (e.g. 😀😁😂 etc.) before translation
+ ## Added automatic database removal
  Added automatic database removal if database file size exceeds 50 MB

+ ## ユニコード絵文字の削除
  翻訳前のUnicode絵文字（😀😁😂など）を削除しました。
+ ## データベースの自動削除機能を追加
  ファイルサイズが50MBを超えた場合、データベースを自動削除する機能を追加

#

# [2.5.0_2](https://github.com/didotb/twitchTransFreeNext/commits/v2.5.0_2)
+ ## Removal of non-Twitch emotes
  Removal of BetterTTV, 7TV, and FrankerFaceZ emotes as requested at #48 
+ ## メッセージからTwitch以外のエモートを削除
  #48 で要望のあったBetterTTV、7TV、FrankerFaceZのエモートの削除。

#

# [2.5.0_1](https://github.com/didotb/twitchTransFreeNext/commits/v2.5.0_1)
+ ## Use SQLite database to reduce DeepL limit 
  The bot sometimes breaks when using DeepL for long periods because of DeepL word limit per 24 hours.

  In order to prevent this I added a feature which the bot will check the local database first if the message was already translated, and use the translation from the database.

  If however, the message wasn't found in the database, it will function normally as it did back then, then save the translation to the database for future use.

+ ## SQLiteデータベースを使用してDeepLの制限を軽減 
  DeepLを長時間使用すると、DeepLの24時間あたりの単語数制限のため、ボットが壊れることがある。

  これを防ぐために、メッセージがすでに翻訳されている場合は、ボットがまずローカルのデータベースをチェックし、データベースからの翻訳を使用する機能を追加しました。

  しかし、そのメッセージがデータベースで見つからなかった場合は、当時と同じように機能し、その後、将来の使用のために翻訳をデータベースに保存します。