### PR TITLE
長過ぎるコメント文をTTSにおいて省略する機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Delete_Words            = ['saatanNooBow', 'BikuBikuTest']
 
 # Any emvironment, set it to `True`, then text will be read by TTS voice!
 # gTTS_In:User Input Text, gTTS_Out:Bot Output Text
-gTTS_In                 = True
-gTTS_Out                = True
+TTS_In                  = True
+TTS_Out                 = True
 
 # if you make TTS for only few lang, please add langID in the list
 # for example, ['ja'] means Japanese only, ['ko','en'] means Korean and English are TTS!
@@ -96,6 +96,8 @@ Debug                   = False
 | TTS_Out | Bot output text will be read by TTS voice! |
 | gTTS_In | It's deprecated config, please use TTS_In instead. |
 | gTTS_Out | It's deprecated config, please use TTS_Out instead. |
+| TTS_TextMaxLength | You can specify TTS's read comment max length. If comment has over length from this, it will omit and added TTS_MessageForOmitting on postfix. |
+| TTS_MessageForOmitting | A message for omitting TTS's read comment. The TTS puts this message  on the omitted message. |
 | CeVIO_Cast | The cast name of CeVIO, for example "さとうささら". This option is enabled only when TTS_Kind = "CeVIO". |
 | ReadOnlyTheseLang | You can set the TTS language! |
 | Debug | You can check some error message using Debug mode (Debug = True)|

--- a/config.py
+++ b/config.py
@@ -27,6 +27,8 @@ TTS_In                  = True
 TTS_Out                 = True
 TTS_Kind                = "gTTS" # You can choice "CeVIO" if you want to use CeVIO as TTS.
 # CeVIO_Cast            = "さとうささら" # When you are using CeVIO, you must set voice cast name.
+TTS_TextMaxLength       = 0
+TTS_MessageForOmitting  = "以下略"
 
 # if you make TTS for only few lang, please add langID in the list
 # for example, ['ja'] means Japanese only, ['ko','en'] means Korean and English are TTS!


### PR DESCRIPTION
# What?
- 長過ぎるコメント文をTTS読み上げに対して省略する機能を追加しました
- 一定の長さ以上の場合、コメントが省略されたことを通知するための言葉に置き換えます
- デフォルトでは設定値が0で、省略が行われない(以前と同等の動作)になるように実装してあります

# Why?
- 長文を貼り付ける荒らしにあって、読み上げが実質的にフリーズしたため、あったほうがいいなと考えました

# Note
- もしかしたら設定値の変数名はもうちょっといい名前があるかもしれないんですが、いいのが思いつかなかった感じなので提案してもらえると嬉しかったりシマス 🙇 