### PR TITLE
Fix for translating messages with quotation marks

### DIFF
--- a/database_controller.py
+++ b/database_controller.py
@@ -29,16 +29,18 @@ try:									# en:Create translation table	ja:翻訳テーブルの作成
 		TRANSLATION TEXT);''')
 	print("Table created.")
 except sqlite3.OperationalError as e:  # en:Continue if table exists   ja:テーブルが存在する場合、続行する
-	print(e)
+	print(f'sqlite3.OperationalError {e}')
 	pass
 
 async def save(message,translation,dlang):	# en:Save the translations   ja:翻訳を保存する
-	db.execute(f'INSERT INTO {table_name} (MESSAGE,DLANG,TRANSLATION) VALUES (\"{message}\", \"{dlang}\", \"{translation}\");')
+	params = (message, dlang, translation)
+	db.execute(f'INSERT INTO {table_name} (MESSAGE,DLANG,TRANSLATION) VALUES (?,?,?);',params)
 	db.commit()
 
 async def get(message,dlang):  # en:Get the translations    ja:翻訳を入手する
 	# en:Return translation or None if nothing found   ja:翻訳を返すか、何も見つからなければ None を返す
-	return db.execute(f'SELECT TRANSLATION FROM {table_name} WHERE MESSAGE="{message}" AND DLANG="{dlang}"').fetchone()
+	params = (message,dlang)
+	return db.execute(f'SELECT TRANSLATION FROM {table_name} WHERE MESSAGE=? AND DLANG=?',params).fetchone()
 
 def delete(target_size:int = 52428800):
 	size = os.path.getsize(db_file)


### PR DESCRIPTION
Messages containing quotation marks (" and possibly ') caused the translation database operations to fail, as the input to the SQL operations was not sanitized. I modified the db.execute calls to use sqlite3 parameter passing that automatically fixes the input so that stray quotation marks don't confuse the SQL interpreter. This should let twitchTransFreeNext properly translate messages that include quotation marks. (I also changed the exception handling for trying to create the table when it already exists to make it clearer where the message comes from, but that is not important for the quotation mark fix) 